### PR TITLE
Encapuslate energy parameters in a struct

### DIFF
--- a/scripts/analyze/analyze_sequence.m
+++ b/scripts/analyze/analyze_sequence.m
@@ -1,4 +1,4 @@
-function [x,d,p,E] = analyze_sequence( sequence, epsilon, delta, calc_m2 );
+function [x,d,p,E] = analyze_sequence( sequence, params, calc_m2 );
 % analyze_sequence( sequence );
 % analyze_sequence( sequence, epsilon, delta );
 % 
@@ -7,21 +7,16 @@ function [x,d,p,E] = analyze_sequence( sequence, epsilon, delta, calc_m2 );
 %
 % INPUT
 %  sequence = sequence like 'AAACCCGGA'
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
+%  params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
 %  calc_m2 = do mutate-and-map simulation [default 1]
 %
 % (C) R. Das, Stanford University
 
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 if ~exist( 'calc_m2','var') calc_m2 = 1; end;
-
 N = length( sequence );
 
-[x,d,p,E] = get_conformations('',sequence,epsilon,delta);
+[x,d,p,E] = get_conformations('',sequence,params);
 
 clf; 
 subplot(1,2,1); 
@@ -29,7 +24,7 @@ draw_conformations(x,d,p,8,sequence,E);
 
 subplot(1,2,2);
 if calc_m2; subplot(2,2,2); end
-bpp = get_bpp(x,d,p,epsilon,delta);
+bpp = get_bpp(x,d,p,params);
 imagesc(bpp,[0 1]); axis image
 hold on; plot([0.5:N+0.5],[0.5:N+0.5]); title( ['BPP for ',sequence] );
 colormap( 1 - gray(100));

--- a/scripts/analyze/get_M2seq.m
+++ b/scripts/analyze/get_M2seq.m
@@ -1,21 +1,17 @@
-function [M2seq, profile] = get_M2seq(sequence,epsilon,delta);
-% [M2seq, profile] = get_M2seq(sequence,epsilon,delta);
+function [M2seq, profile] = get_M2seq(sequence,params);
+% [M2seq, profile] = get_M2seq(sequence,params);
 %
 % INPUT
 %  sequence = sequence like 'AAACCCGGA'
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
-%
+%    params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
 % (C) R. Das, Stanford University
 
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
+
 N = length( sequence );
 
 [x,d,p] = get_conformations('',sequence);
-bpp = get_bpp(x,d,p,epsilon,delta);
+bpp = get_bpp(x,d,p,params);
 profile = 1 - sum(bpp);
 
 M2seq = [];
@@ -23,6 +19,6 @@ for n = 1:N
     sequence_mut = sequence;
     sequence_mut(n) = reverse_complement_TOYFOLD( sequence(n) );
     [x,d,p] = get_conformations('',sequence_mut);
-    bpp = get_bpp(x,d,p,epsilon,delta);
+    bpp = get_bpp(x,d,p,params);
     M2seq = [M2seq; 1-sum(bpp)];
 end

--- a/scripts/conformations/get_conformations.m
+++ b/scripts/conformations/get_conformations.m
@@ -1,5 +1,5 @@
-function [x,d,p,E] = get_conformations( secstruct, sequence, epsilon, delta );
-% [x,d,p] = get_conformations( secstruct, sequence );
+function [x,d,p,E] = get_conformations( secstruct, sequence, params);
+% [x,d,p] = get_conformations( secstruct[, sequence, params] );
 %
 % Figure out all the conformations (bead positions)
 %  that are consistent with a secondary structure.
@@ -18,10 +18,8 @@ function [x,d,p,E] = get_conformations( secstruct, sequence, epsilon, delta );
 % sequence  = [optional] Input sequence (array of 0's and 1's) with
 %                 'colors'. Required if you want secstruct's to be
 %                 enumerated.
-%  epsilon = [optional] energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = [optional] energy penalty for each bend (use positive number for penalty), 
-
+% params    = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
+%
 % OUTPUT
 %  x = [Nbeads x Nconformations] all sets of conformations.
 %        If there are no base pairs specified, should get
@@ -32,9 +30,7 @@ function [x,d,p,E] = get_conformations( secstruct, sequence, epsilon, delta );
 %  E = [Nconformations] Energies for each conformation.
 % 
 % (C) R. Das, Stanford University, 2020
-
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 
 x = [];
 
@@ -161,7 +157,7 @@ for i = 2:N
 end
 
 % re-order trajectories, sorted by the number of bends
-E =  get_energy(d,p,epsilon,delta);
+E =  get_energy(d,p,params);
 [E,idx] = sort( E );
 
 x = x(:,idx);

--- a/scripts/design/enumerative_design.m
+++ b/scripts/design/enumerative_design.m
@@ -1,5 +1,5 @@
-function [sequences,p_target,x,d,p] = enumerative_design( secstruct, pattern, epsilon, delta );
-% [sequences,p_target,x,d,p] = enumerative_design( secstruct [, pattern, epsilon, delta] );
+function [sequences,p_target,x,d,p] = enumerative_design( secstruct, pattern, params );
+% [sequences,p_target,x,d,p] = enumerative_design( secstruct [, pattern, params] );
 %
 %   Emnumerate over all sequences that could form target secondary
 %    structure (and conform to optional design pattern) and see which ones
@@ -14,10 +14,7 @@ function [sequences,p_target,x,d,p] = enumerative_design( secstruct, pattern, ep
 %                If not specified, code will use ANNNNNN... (note that
 %                first base can be set to A without loss of generality in
 %                current energy model)
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
+%  params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
 %
 %
 % Outputs
@@ -36,8 +33,8 @@ function [sequences,p_target,x,d,p] = enumerative_design( secstruct, pattern, ep
 % (C) R. Das, Stanford University, 2020
 N = length( secstruct );
 if ~exist( 'pattern', 'var' ) pattern = ['A',repmat( 'N', 1, N-1 )]; end;
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
+
 assert( length( pattern ) == length( secstruct ) );
 
 sequences = get_sequences_for_pattern( pattern );
@@ -51,7 +48,7 @@ x_target = {}; d_target = {}; p_target = [];
 Z = []; Z_target = [];
 for q = 1:length( sequences )
     sequence = sequences{q};
-    [p_target(q),x{q},d{q},p{q}] = test_design(sequence,secstruct,epsilon,delta);
+    [p_target(q),x{q},d{q},p{q}] = test_design(sequence,secstruct,params);
 end
 [p_sort,idx] = sort( -p_target );
 p_target = p_target( idx );
@@ -65,12 +62,12 @@ colormap( 1 - gray(100));
 clf
 subplot(1,2,1);
 q = 1;
-imagesc( get_bpp(x{q},d{q},p{q},epsilon,delta),[0 1] );
+imagesc( get_bpp(x{q},d{q},p{q},params),[0 1] );
 title( ['Best design\newline',sequences{q},'\newline',num2str(p_target(q))] );
 
 subplot(1,2,2);
 q = length(x);
-imagesc(get_bpp(x{end},d{end},p{end},epsilon,delta),[0 1] );
+imagesc(get_bpp(x{end},d{end},p{end},params),[0 1] );
 title( ['Worst design\newline',sequences{end},'\newline',num2str(p_target(q))] );
 
 

--- a/scripts/design/test_design.m
+++ b/scripts/design/test_design.m
@@ -1,5 +1,5 @@
-function [p_target,x,d,p] = test_design(sequence,secstruct,epsilon,delta);
-% [p_target,x,d,p] = test_design(sequence,secstruct,epsilon,delta);
+function [p_target,x,d,p] = test_design(sequence,secstruct,params);
+% [p_target,x,d,p] = test_design(sequence,secstruct,params);
 %
 % Main script for testing if a sequence folds well into target 
 %   secondary structure.
@@ -7,11 +7,8 @@ function [p_target,x,d,p] = test_design(sequence,secstruct,epsilon,delta);
 % Inputs
 %  sequence  = sequence like 'AAACCCGGA'
 %  secstruct = target secondary structure in dot parens notation
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
-%
+%  params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
+
 % Output
 %  p_target = Fraction of conformations with target 
 %                secondary structure. (Higher is better.)
@@ -24,13 +21,12 @@ function [p_target,x,d,p] = test_design(sequence,secstruct,epsilon,delta);
 %
 % (C) Rhiju Das, Stanford University 2020
 
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 
 [x,d,p] = get_conformations('',sequence);
-Z = get_Z(x,d,p,epsilon,delta);
+Z = get_Z(x,d,p,params);
 
-[x_target,d_target,p_target] = get_conformations(secstruct,sequence);
-Z_target = get_Z(x_target,d_target,p_target,epsilon,delta);
+[x_target,d_target,p_target] = get_conformations(secstruct,sequence,params);
+Z_target = get_Z(x_target,d_target,p_target,params);
 
 p_target = Z_target/Z;

--- a/scripts/scoring/get_Z.m
+++ b/scripts/scoring/get_Z.m
@@ -1,4 +1,4 @@
-function [Z,conf_prob] = get_Z(x,d,p,epsilon,delta);
+function [Z,conf_prob] = get_Z(x,d,p,params);
 % [Z,conf_prob] = get_Z(x,d,p,epsilon,delta);
 %
 % Partition function calculation.
@@ -10,11 +10,7 @@ function [Z,conf_prob] = get_Z(x,d,p,epsilon,delta);
 %  d = [Nbeads x Nconformations] input directions (array of +/-1's)
 %  p = [Nbeads x Nconformations] partners  (0 if bead is unpaired,
 %        otherwise index of partner from 1,... Nbeads )
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
-%
+%  params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
 %
 % OUTPUT
 % secstruct = Secondary structure in dot-parens notation, e.g.
@@ -27,10 +23,9 @@ function [Z,conf_prob] = get_Z(x,d,p,epsilon,delta);
 % 
 % (C) R. Das, Stanford University, 2020
 
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 
-E = get_energy(d,p,epsilon,delta);
+E = get_energy(d,p,params);
 Z = sum( exp( -E ) );
 conf_prob = exp(-E)/Z;
 

--- a/scripts/scoring/get_bpp.m
+++ b/scripts/scoring/get_bpp.m
@@ -1,4 +1,4 @@
-function  bpp = get_bpp(x,d,p,epsilon,delta);
+function  bpp = get_bpp(x,d,p,params);
 % bpp = get_bpp(x,d,p,epsilon,delta);
 %
 % Get base pair probability matrix from get_conformations() output of
@@ -11,10 +11,7 @@ function  bpp = get_bpp(x,d,p,epsilon,delta);
 %  d = [Nbeads x Nconformations] input directions (array of +/-1's)
 %  p = [Nbeads x Nconformations] partners  (0 if bead is unpaired,
 %        otherwise index of partner from 1,... Nbeads )
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
+%  params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
 %
 % Output
 % bpp = [Nbeads x Nbeads] matrix of probabilities (from 0 to 1) that  
@@ -22,8 +19,9 @@ function  bpp = get_bpp(x,d,p,epsilon,delta);
 %
 % 
 % (C) R. Das, Stanford University
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 
-[Z,conf_prob] = get_Z(x,d,p,epsilon,delta);
+[Z,conf_prob] = get_Z(x,d,p,params);
 N = size(x,1);
 bpp = zeros(N,N);
 for q = 1:size(x,2)

--- a/scripts/scoring/get_default_energy_parameters.m
+++ b/scripts/scoring/get_default_energy_parameters.m
@@ -1,0 +1,18 @@
+function params = get_default_energy_parameters()
+% params = get_default_energy_parameters()
+%
+% Currently epsilon = -2 (base pair strength) and 
+%           delta = 1 (penalty for bending)
+%
+% which produces stable hairpins without requiring too many base pairs, as
+%   is appropriate for beads that represent domains. Also proudces a lot 
+%   of pseudoknots.
+%
+% OUTPUT
+% params = struct with fields for delta, epsilon values.
+%
+% (C) R. Das, Stanford University 2020.
+
+params = struct();
+params.epsilon = -2;
+params.delta = 1;

--- a/scripts/scoring/get_energy.m
+++ b/scripts/scoring/get_energy.m
@@ -1,20 +1,21 @@
-function E =  get_energy(d,p,epsilon,delta)
-% E = get_energy(d,p)
+function E =  get_energy(d,p,params)
+% E = get_energy(d,p,params)
 % 
 % Energy in toyfold model
 %
+% Inputs
 %  d = [Nbeads x Nconformations] input directions (array of +/-1's)
 %  p = [Nbeads x Nconformations] partners  (0 if bead is unpaired,
 %        otherwise index of partner from 1,... Nbeads )
-%  epsilon = energy bonus for each pair (use negative number for bonus), 
-%               units of kT. [Default -2]
-%  delta = energy penalty for each bend (use positive number for penalty), 
-%               units of kT. [Default 1]
+% params = Energy parameter values for delta, epsilon, etc. [MATLAB struct]
+%
+% Output
+% E = [Nconformations] energies for each conformation 
+%
+% (C) R. Das, Stanford University 2020
 
-
-if ~exist( 'epsilon','var') epsilon = -2; end;
-if ~exist( 'delta','var') delta = 1; end;
+if ~exist( 'params','var') params = get_default_energy_parameters(); end;
 
 num_bends = score_bends(d);
 num_pairs = score_pairs(p);
-E = delta * num_bends + epsilon * num_pairs;
+E = params.delta * num_bends + params.epsilon * num_pairs;

--- a/scripts/unittests/designTest.m
+++ b/scripts/unittests/designTest.m
@@ -1,4 +1,4 @@
-%%
+%% get_nts
 assert( strcmp(get_nts_for_symbol( 'A' ),'A' ) );
 assert( strcmp(get_nts_for_symbol( 'N' ),'ACGU' ) ); 
 assert( strcmp(get_nts_for_symbol( 'W' ),'AU' ) );
@@ -6,7 +6,7 @@ assert( strcmp(get_nts_for_symbol( 'W' ),'AU' ) );
 sequences = get_sequences_for_pattern( 'AANUU' );
 assert( all( strcmp(sequences,{'AAAUU','AACUU','AAGUU','AAUUU'} ) ) );
 
-%%
+%% enumerative_design
 % design by enumeration! Small hairpin
 secstruct = '((.))';
 [sequences,p_target,x,d,p] = enumerative_design( secstruct );
@@ -16,7 +16,7 @@ assert( p_target(end) < p_target(1) );
 [x,d,p] = analyze_sequence(sequences{1});
 assert( all( p(:,1) == secstruct_to_partner(secstruct) ) );
 
-% force A/U only
+% enumerative_design force A/U only
 [sequencesW,p_targetW,x,d,p] = enumerative_design( '((.))','AWWWW' );
 assert( strcmp(sequencesW{1},'AUAAU') );
 assert( p_targetW(1) > 0.1 );
@@ -26,8 +26,7 @@ assert( p_targetW(end) == p_target(end) );
 [x,d,p] = analyze_sequence(sequences{1});
 assert( all( p(:,1) == secstruct_to_partner(secstruct) ) );
 
-%%
-% check pseudoknot design
+%% check pseudoknot design
 secstruct = '(..[)]';
 [sequences,p_target,x,d,p] = enumerative_design( secstruct );
 assert( strcmp(sequences{1},'ACCUUA') );

--- a/test_pseudoknot_frequency.m
+++ b/test_pseudoknot_frequency.m
@@ -5,28 +5,29 @@
 %
 % Bonafide pseudoknot sequence
 %%
-epsilon = -2; delta = 1; % original default --> stable
+params = get_default_energy_parameters();
+params.epsilon = -2; params.delta = 1; % original default --> stable
 sequence = 'AGAAGCUAC';
 
-epsilon = -2; delta = 4; % try to get more cooperativity
+params.epsilon = -2; params.delta = 4; % try to get more cooperativity
 sequence = 'CAGAAAAGGGCUGAACCC'; % now need 3-bp to get stable stems
 clf;
 tic
-[x,d,p,E] = analyze_sequence( sequence, epsilon, delta, 0 );
+[x,d,p,E] = analyze_sequence( sequence, params, 0 );
 
 % NOTE -- alternative structure arises where bottom stem opens.
 
 toc
 %%
 idx = find( check_pseudoknot(p) );
-draw_conformations( x(:,idx), d(:,idx), p(:,idx), 8, sequence );
+draw_conformations( x(:,idx), d(:,idx), p(:,idx), 8, sequence, E);
 
 
 %%
 % Higher delta, lower epsilon results in fewer pseudoknots, as expected.
 nts = 'ACGU'; N = 14;
 rand_sequence = nts(randi(4,1,N));
-epsilon = -2; delta = 5; % try to get more cooperativity
-[x,d,p] = analyze_sequence( rand_sequence, epsilon, delta, 0);
+params.epsilon = -2; params.delta = 5; % try to get more cooperativity
+[x,d,p] = analyze_sequence( rand_sequence, params, 0);
 fprintf('Top conformations are pseudoknot?\n')
 check_pseudoknot(p(:,1:8))


### PR DESCRIPTION
The struct 'params' has `delta` and `epsilon` for now. But pretty soon will have additional energy parameter values and options, so it will get cumbersome to pass around as separate variables.
